### PR TITLE
Added a default Accept header which accepts Siren media type first

### DIFF
--- a/scripts/siren/module.js
+++ b/scripts/siren/module.js
@@ -31,6 +31,8 @@ angular
   })
   .factory('navigator', ['$http', '$rootScope', '$q', '$state', 'classRouter',
       function($http, $rootScope, $q, $state, classRouter) {
+
+    $http.defaults.headers.common.Accept = 'application/vnd.siren+json, application/json, text/plain, */*';
     return {
       cache: [],
       current: null,


### PR DESCRIPTION
Currently Angular requests `application/json` by default.  Within the factory for the navigator I had it instead set a default accept header which puts `application/vnd.siren+json` first.
