### PR TITLE
Fixes #6 by allowing Submit button rendering even if fields of the Action does not have any fields

### DIFF
--- a/partials/entity.html
+++ b/partials/entity.html
@@ -36,20 +36,18 @@
           </accordion-heading>
           <tabset>
             <tab heading="Form">
-              <div ng-show="action.fields.length">
                 <form class="form-horizontal">
-
-                  <br/>
-                  <srn-action value="action"></srn-action>
-                  <br/>
-
+                      <br/>
+                          <div ng-if="action.fields.length">
+                              <srn-action value="action"></srn-action>
+                          </div>
+                      <br/>
                   <div class="control-group">
                     <div class="controls">
                       <button type="submit" class="btn btn-default" ng-click="execute(action)">Submit</button>
                     </div>
                   </div>
                 </form>
-              </div>
             </tab>
             <tab heading="Source">
               <pre>{{ action | prettify }}</pre>

--- a/scripts/siren/module.js
+++ b/scripts/siren/module.js
@@ -106,7 +106,6 @@ angular
             var str = [];
             for(var p in obj)
               if (obj.hasOwnProperty(p)) {
-                console.log('obj[p]:' + obj[p]);
                 if (typeof obj[p] != 'undefined') {
                     str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
                 }
@@ -124,8 +123,8 @@ angular
 
           return deferred.promise;
         } else {
-
-          if (contentType === 'application/json') {
+          if (contentType === 'application/json' 
+             || (contentType.startsWith('application/vnd') && contentType.endsWith('json')) ) {
             options.data = {};
             angular.forEach(action.fields, function(field) {
               options.data[field.name] = field.value;

--- a/scripts/siren/module.js
+++ b/scripts/siren/module.js
@@ -106,7 +106,10 @@ angular
             var str = [];
             for(var p in obj)
               if (obj.hasOwnProperty(p)) {
-                str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+                console.log('obj[p]:' + obj[p]);
+                if (typeof obj[p] != 'undefined') {
+                    str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+                }
               }
             return str.join("&");
           };
@@ -121,6 +124,7 @@ angular
 
           return deferred.promise;
         } else {
+
           if (contentType === 'application/json') {
             options.data = {};
             angular.forEach(action.fields, function(field) {
@@ -131,10 +135,13 @@ angular
             angular.forEach(action.fields, function(field) {
               data.push(encodeURIComponent(field.name) + '=' + encodeURIComponent(field.value));
             });
-
-            options.data = data.join('&');
+            if (data.length === 0) {
+                options.data = {};
+            } else {
+                options.data = data.join('&');
+            }
           }
-
+          
           var deferred = $q.defer();
 
           $http(options).success(function(data, status, headers, config) {


### PR DESCRIPTION
I have used "ng-if" instead of "ng-show" because in case of srn-action is evaluated when there is no
"action.fields" defined it still throws an exception because of loop on
"scope.action.fields.length" variable.
On the browser console it is shown as following:

TypeError: Cannot read property 'length' of undefined
    at link (http://localhost:3001/scripts/app.js:56:46)
    at k (http://localhost:3001/scripts/vendor/angular.min.js:44:444)
    at e (http://localhost:3001/scripts/vendor/angular.min.js:40:139)
    at k (http://localhost:3001/scripts/vendor/angular.min.js:44:382)
    at e (http://localhost:3001/scripts/vendor/angular.min.js:40:139)
    at k (http://localhost:3001/scripts/vendor/angular.min.js:44:382)
    at e (http://localhost:3001/scripts/vendor/angular.min.js:40:139)
    at e.$transcludeFn (http://localhost:3001/scripts/vendor/angular.min.js:39:205)
    at link (http://localhost:3001/scripts/vendor/ui-bootstrap-custom-tpls-0.10.0.min.js:8:5672)
    at k (http://localhost:3001/scripts/vendor/angular.min.js:44:444) <srn-action value="action" class="ng-isolate-scope ng-scope">

With ng-if element is not evaluated at all and we do not get the exception above.